### PR TITLE
Add Debian/Ubuntu build instructions

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -49,6 +49,9 @@ Install libvcdinfo:
 
 Now configure should work:
   $ ./configure --with-boost-libdir=/usr/lib/x86_64-linux-gnu
+  
+If you want a static build (to copy the executables and run on other Linux without worrying about dependencies):
+  $ ./configure --with-boost-libdir=/usr/lib/x86_64-linux-gnu LDFLAGS="-static" LIBS="-lpthread"
 
 Compile:
   $ make

--- a/INSTALL
+++ b/INSTALL
@@ -44,6 +44,9 @@ Download the following libraries (not available on stable Ubuntu or Debian at th
 Install the downloaded packages:
   # dpkg -i lib{cdio,iso}*.deb
 
+Install libvcdinfo:
+  # apt-get install libvcdinfo0 libvcdinfo-dev
+
 Now configure should work:
   $ ./configure --with-boost-libdir=/usr/lib/x86_64-linux-gnu
 

--- a/INSTALL
+++ b/INSTALL
@@ -26,3 +26,30 @@ PSXImager can be compiled and installed in the usual way:
 
 Installation is not strictly necessary; the three binaries built in the
 "src" directory are stand-alone programs.
+
+Ubuntu 15.04 Installation
+=========================
+Install autoconf:
+  # apt-get install autoconf build-essential
+
+Install boost dev libraries:
+  # apt-get install libboost-all-dev
+
+Download the following libraries (not available on stable Ubuntu or Debian at the moment), scroll down and click amd64 or i386 depending on your arch, then pick a download link:
+  https://packages.debian.org/experimental/libiso9660-dev
+  https://packages.debian.org/experimental/libiso9660-9
+  https://packages.debian.org/experimental/libcdio-dev
+  https://packages.debian.org/experimental/libcdio15
+
+Install the downloaded packages:
+  # dpkg -i lib{cdio,iso}*.deb
+
+Now configure should work:
+  $ ./configure --with-boost-libdir=/usr/lib/x86_64-linux-gnu
+
+Compile:
+  $ make
+
+Compiled files are under src/:
+  $ ls src/psx{build,inject,rip}
+  src/psxbuild  src/psxinject  src/psxrip


### PR DESCRIPTION
Dependencies versions are not easy to meet under Debian/Ubuntu
