### PR TITLE
Changes to accommodate libcdio 2.0.0-1

### DIFF
--- a/src/psxrip.cpp
+++ b/src/psxrip.cpp
@@ -107,7 +107,7 @@ static void dumpFilesystem(CdIo_t * image, ofstream & catalog, bool writeLBNs,
 	cdio_info("Dumping '%s' as '%s'", inputPath.c_str(), dirName.c_str());
 
 	// Read the directory entries
-	CdioList_t * entries = iso9660_fs_readdir(image, inputPath.c_str(), false);
+	CdioList_t * entries = iso9660_fs_readdir(image, inputPath.c_str());
 	if (!entries) {
 		throw runtime_error((format("Error reading ISO 9660 directory '%1%'") % inputPath).str());
 	}
@@ -227,7 +227,7 @@ static void dumpFilesystem(CdIo_t * image, ofstream & catalog, bool writeLBNs,
 	// Close the catalog record for the directory
 	catalog << string(level * 2, ' ') << "}\n";
 
-	_cdio_list_free(entries, true);
+	_cdio_list_free(entries, true, (CdioDataFree_t) iso9660_stat_free);
 }
 
 
@@ -297,7 +297,7 @@ static void dumpImage(CdIo_t * image, const boost::filesystem::path & outputPath
 static void dumpLBNTable(CdIo_t * image, const string & inputPath = "", ostream & output = cout)
 {
 	// Read the directory entries
-	CdioList_t * entries = iso9660_fs_readdir(image, inputPath.c_str(), false);
+	CdioList_t * entries = iso9660_fs_readdir(image, inputPath.c_str());
 	if (!entries) {
 		throw runtime_error((format("Error reading ISO 9660 directory '%1%'") % inputPath).str());
 	}


### PR DESCRIPTION
Offending changes were made on
libcdio/73800fc0cd81a735764f79b7f3f957d8a71eb02c -- _cdio_list_free adds an extra function parameter.
libcdio/bf7ee89d6eb22887f356d90d03c03e4255dd236f -- cdio_fs_readdir drops its last parameter.