### PR TITLE
Windows support

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -26,3 +26,27 @@ PSXImager can be compiled and installed in the usual way:
 
 Installation is not strictly necessary; the three binaries built in the
 "src" directory are stand-alone programs.
+
+
+Installation for Windows
+========================
+
+You can build PSXImager for Windows using MSYS2 environment.
+
+  1. Download MSYS2 from the official website: https://www.msys2.org/
+  2. After installation, open "mingw32.exe" in MSYS2 root folder.
+  3. Install compiler and necessary packages:
+
+     pacman -S --noconfirm autoconf automake make
+     pacman -S --noconfirm mingw-w64-i686-toolchain mingw-w64-i686-boost \
+         mingw-w64-i686-libcdio mingw-w64-i686-vcdimager
+
+  4. Run build commands:
+
+     ./bootstrap
+     ./configure --host=i686-w64-mingw32 --with-boost=/mingw32 \
+         LDFLAGS="-s -static"
+     make
+
+The three binaries in "src" directory are stand-alone and can be run on
+any Windows machine (no additional libraries needed).

--- a/src/psxbuild.cpp
+++ b/src/psxbuild.cpp
@@ -825,7 +825,7 @@ public:
 
 	void visit(FileNode & file)
 	{
-		ifstream f(file.path.c_str(), ifstream::in | ifstream::binary);
+		ifstream f(file.path.string().c_str(), ifstream::in | ifstream::binary);
 		if (!f) {
 			throw runtime_error((format("Cannot open file %1%") % file.path).str());
 		}
@@ -940,7 +940,7 @@ static void writeSystemArea(ofstream & image, const Catalog & cat)
 // Print usage information and exit.
 static void usage(const char * progname, int exitcode = 0, const string & error = "")
 {
-	cout << "Usage: " << boost::filesystem::path(progname).filename().native() << " [OPTION...] <input>[.cat] [<output>[.bin]]" << endl;
+	cout << "Usage: " << boost::filesystem::path(progname).filename().string() << " [OPTION...] <input>[.cat] [<output>[.bin]]" << endl;
     cout << "  -c, --cuefile                   Create a .cue file" << endl;
 	cout << "  -v, --verbose                   Be verbose" << endl;
 	cout << "  -V, --version                   Display version information and exit" << endl;
@@ -1008,7 +1008,7 @@ int main(int argc, char ** argv)
 
 		Catalog cat;
 
-		ifstream catalogFile(catalogName.c_str());
+		ifstream catalogFile(catalogName.string().c_str());
 		if (!catalogFile) {
 			throw runtime_error((format("Cannot open catalog file %1%") % catalogName).str());
 		}
@@ -1069,7 +1069,7 @@ int main(int argc, char ** argv)
 		boost::filesystem::path imageName = outputPath;
 		imageName.replace_extension(".bin");
 
-		ofstream image(imageName.c_str(), ofstream::out | ofstream::binary | ofstream::trunc);
+		ofstream image(imageName.string().c_str(), ofstream::out | ofstream::binary | ofstream::trunc);
 		if (!image) {
 			throw runtime_error((format("Error creating image file %1%") % imageName).str());
 		}
@@ -1157,7 +1157,7 @@ int main(int argc, char ** argv)
 			boost::filesystem::path cueName = outputPath;
 			cueName.replace_extension(".cue");
 
-			ofstream cueFile(cueName.c_str(), ofstream::out | ofstream::trunc);
+			ofstream cueFile(cueName.string().c_str(), ofstream::out | ofstream::trunc);
 			if (!cueFile) {
 				throw runtime_error((format("Error creating cue file %1%") % cueName).str());
 			}

--- a/src/psxinject.cpp
+++ b/src/psxinject.cpp
@@ -48,7 +48,7 @@ using namespace std;
 // Print usage information and exit.
 static void usage(const char * progname, int exitcode = 0, const string & error = "")
 {
-	cout << "Usage: " << boost::filesystem::path(progname).filename().native() << " [OPTION...] <input>[.bin/cue] <repl_file_path> <new_file>" << endl;
+	cout << "Usage: " << boost::filesystem::path(progname).filename().string() << " [OPTION...] <input>[.bin/cue] <repl_file_path> <new_file>" << endl;
 	cout << "  -v, --verbose                   Be verbose" << endl;
 	cout << "  -V, --version                   Display version information and exit" << endl;
 	cout << "  -?, --help                      Show this help message" << endl;
@@ -109,7 +109,7 @@ int main(int argc, char ** argv)
 			imagePath.replace_extension(".bin");
 		}
 
-		CdIo_t * image = cdio_open(imagePath.c_str(), DRIVER_BINCUE);
+		CdIo_t * image = cdio_open(imagePath.string().c_str(), DRIVER_BINCUE);
 		if (image == NULL) {
 			throw runtime_error((format("Error opening input image %1%, or image has wrong type") % imagePath).str());
 		}
@@ -255,10 +255,10 @@ int main(int argc, char ** argv)
 		cdio_destroy(image);
 
 		imagePath.replace_extension(".bin");
-		fstream writeImage(imagePath.c_str(), fstream::in | fstream::out | fstream::binary);
+		fstream writeImage(imagePath.string().c_str(), fstream::in | fstream::out | fstream::binary);
 
 		// Read the new file and inject it
-		ifstream file(newFileName.c_str(), ifstream::in | ifstream::binary);
+		ifstream file(newFileName.string().c_str(), ifstream::in | ifstream::binary);
 		if (!file) {
 			throw runtime_error((format("Cannot open file %1%") % newFileName).str());
 		}

--- a/src/psxrip.cpp
+++ b/src/psxrip.cpp
@@ -63,7 +63,7 @@ static void print_ltime(ofstream & f, const iso9660_ltime_t & l)
 // Dump system area data from image to file.
 static void dumpSystemArea(CdIo_t * image, const boost::filesystem::path & fileName)
 {
-	ofstream file(fileName.c_str(), ofstream::out | ofstream::binary | ofstream::trunc);
+	ofstream file(fileName.string().c_str(), ofstream::out | ofstream::binary | ofstream::trunc);
 	if (!file) {
 		throw runtime_error((format("Cannot create system area file %1%\n") % fileName).str());
 	}
@@ -190,7 +190,7 @@ static void dumpFilesystem(CdIo_t * image, ofstream & catalog, bool writeLBNs,
 
 			// Dump the file contents
 			boost::filesystem::path outputFileName = outputDirName / entryName;
-			ofstream file(outputFileName.c_str(), ofstream::out | ofstream::binary | ofstream::trunc);
+			ofstream file(outputFileName.string().c_str(), ofstream::out | ofstream::binary | ofstream::trunc);
 			if (!file) {
 				throw runtime_error((format("Cannot create output file %1%") % outputFileName).str());
 			}
@@ -249,7 +249,7 @@ static void dumpImage(CdIo_t * image, const boost::filesystem::path & outputPath
 	systemAreaName.replace_extension(".sys");
 
 	// Create output catalog file
-	ofstream catalog(catalogName.c_str(), ofstream::out | ofstream::trunc);
+	ofstream catalog(catalogName.string().c_str(), ofstream::out | ofstream::trunc);
 	if (!catalog) {
 		throw runtime_error((format("Cannot create catalog file %1%") % catalogName).str());
 	}
@@ -366,7 +366,7 @@ static void dumpLBNTable(CdIo_t * image, const string & inputPath = "", ostream 
 // Print usage information and exit.
 static void usage(const char * progname, int exitcode = 0, const string & error = "")
 {
-	cout << "Usage: " << boost::filesystem::path(progname).filename().native() << " [OPTION...] <input>[.bin/cue] [<output_dir>]" << endl;
+	cout << "Usage: " << boost::filesystem::path(progname).filename().string() << " [OPTION...] <input>[.bin/cue] [<output_dir>]" << endl;
 	cout << "  -l, --lbns                      Write LBNs to catalog file" << endl;
 	cout << "  -t, --lbn-table                 Print LBN table and exit" << endl;
 	cout << "  -v, --verbose                   Be verbose" << endl;
@@ -433,7 +433,7 @@ int main(int argc, const char ** argv)
 			inputPath.replace_extension(".bin");
 		}
 
-		CdIo_t * image = cdio_open(inputPath.c_str(), DRIVER_BINCUE);
+		CdIo_t * image = cdio_open(inputPath.string().c_str(), DRIVER_BINCUE);
 		if (image == NULL) {
 			throw runtime_error((format("Error opening input image %1%, or image has wrong type") % inputPath).str());
 		}


### PR DESCRIPTION
# Issue

Windows path uses Unicode characters, thus `boost::filesystem::path` is actually `wchat_t` string. That way functions that expect ASCII strings produce errors while compiling.

# Solution

Always get ASCII string from `boost::filesystem::path` variables.

Closes #10 